### PR TITLE
Adapt usage of moved HTTP permissions

### DIFF
--- a/deployment/src/main/java/io/quarkus/mfa/deployment/QuarkusMfaProcessor.java
+++ b/deployment/src/main/java/io/quarkus/mfa/deployment/QuarkusMfaProcessor.java
@@ -18,7 +18,7 @@ import io.quarkus.mfa.runtime.MfaBuildTimeConfig;
 import io.quarkus.mfa.runtime.MfaIdentityProvider;
 import io.quarkus.mfa.runtime.MfaRecorder;
 import io.quarkus.vertx.http.deployment.VertxWebRouterBuildItem;
-import io.quarkus.vertx.http.runtime.HttpBuildTimeConfig;
+import io.quarkus.vertx.http.runtime.HttpConfiguration;
 import io.quarkus.vertx.http.runtime.security.HttpAuthenticationMechanism;
 
 @BuildSteps(onlyIf = QuarkusMfaProcessor.IsEnabled.class)
@@ -39,11 +39,10 @@ class QuarkusMfaProcessor {
     }
 
     @BuildStep
-    @Record(ExecutionTime.STATIC_INIT)
+    @Record(ExecutionTime.RUNTIME_INIT)
     public void initPermissions(MfaRecorder recorder, MfaBuildTimeConfig mfaBuildTimeConfig,
-            HttpBuildTimeConfig httpBuildTimeConfig) {
-        recorder.initPermissions(mfaBuildTimeConfig, httpBuildTimeConfig);
-
+            HttpConfiguration httpRunTimeConfig) {
+        recorder.initPermissions(mfaBuildTimeConfig, httpRunTimeConfig);
     }
 
     @Record(ExecutionTime.RUNTIME_INIT)

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <quarkus.version>3.4.2</quarkus.version>
+    <quarkus.version>3.6.0</quarkus.version>
     <surefire-plugin.version>3.1.2</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/runtime/src/main/java/io/quarkus/mfa/runtime/MfaRecorder.java
+++ b/runtime/src/main/java/io/quarkus/mfa/runtime/MfaRecorder.java
@@ -14,7 +14,7 @@ import org.jose4j.lang.ByteUtil;
 import io.quarkus.arc.runtime.BeanContainer;
 import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.annotations.Recorder;
-import io.quarkus.vertx.http.runtime.HttpBuildTimeConfig;
+import io.quarkus.vertx.http.runtime.HttpConfiguration;
 import io.quarkus.vertx.http.runtime.PolicyMappingConfig;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.handler.BodyHandler;
@@ -34,7 +34,7 @@ public class MfaRecorder {
     }
 
     // automatically add MFA endpoints to the authentication policy to allow anonymous access.
-    public void initPermissions(MfaBuildTimeConfig mfaBuildTimeConfig, HttpBuildTimeConfig httpBuildTimeConfig) {
+    public void initPermissions(MfaBuildTimeConfig mfaBuildTimeConfig, HttpConfiguration httpRunTimeConfig) {
         PolicyMappingConfig config = new PolicyMappingConfig();
         config.enabled = Optional.of(true);
         config.methods = Optional.of(List.of("GET", "POST"));
@@ -42,8 +42,7 @@ public class MfaRecorder {
                 .of(List.of(mfaBuildTimeConfig.loginView, mfaBuildTimeConfig.logoutView, mfaBuildTimeConfig.loginAction));
         config.policy = "permit";
         config.authMechanism = Optional.empty();
-        httpBuildTimeConfig.auth.permissions.put("quarkus_mfa", config);
-
+        httpRunTimeConfig.auth.permissions.put("quarkus_mfa", config);
     }
 
     public void setupRoutes(BeanContainer beanContainer, MfaBuildTimeConfig buildConfig, RuntimeValue<Router> routerValue) {


### PR DESCRIPTION
Hello fellow devs,

this PR should fix the broken build pipeline for this extension.

HTTP Permissions and Roles policies have been moved from build-time to runtime.

See PR https://github.com/quarkusio/quarkus/pull/36874