### PR TITLE
Modernize MFA extension

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,13 +28,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v5
 
       - name: Set up JDK 11
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: 11
+          java-version: 17
 
       - name: Get Date
         id: get-date

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -5,21 +5,12 @@ on:
     paths:
       - '.github/project.yml'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  release:
-    runs-on: ubuntu-latest
-    name: pre release
-
-    steps:
-      - uses: radcortez/project-metadata-action@master
-        name: retrieve project metadata
-        id: metadata
-        with:
-          github-token: ${{secrets.GITHUB_TOKEN}}
-          metadata-file-path: '.github/project.yml'
-
-      - name: Validate version
-        if: contains(steps.metadata.outputs.current-version, 'SNAPSHOT')
-        run: |
-          echo '::error::Cannot release a SNAPSHOT version.'
-          exit 1
+  pre-release:
+    name: Pre-Release
+    uses: quarkiverse/.github/.github/workflows/pre-release.yml@main
+    secrets: inherit

--- a/.github/workflows/quarkus-snapshot.yaml
+++ b/.github/workflows/quarkus-snapshot.yaml
@@ -26,11 +26,8 @@ jobs:
     if: github.actor == 'quarkusbot' || github.actor == 'quarkiversebot' || github.actor == '<ADMIN>'
 
     steps:
-      - name: Install yq
-        run: sudo add-apt-repository ppa:rmescandon/yq && sudo apt update && sudo apt install yq -y
-
       - name: Set up Java
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: ${{ env.JAVA_VERSION }}
@@ -41,7 +38,7 @@ jobs:
           path: current-repo
 
       - name: Checkout Ecosystem
-        uses: actions/checkout@v2
+        uses: actions/checkout@v5
         with:
           repository: ${{ env.ECOSYSTEM_CI_REPO }}
           path: ecosystem-ci

--- a/.github/workflows/release-perform.yml
+++ b/.github/workflows/release-perform.yml
@@ -1,0 +1,28 @@
+name: Quarkiverse Perform Release
+run-name: Perform ${{github.event.inputs.tag || github.ref_name}} Release
+on:
+  push:
+    tags:
+      - '*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to release'
+        required: true
+
+permissions:
+  attestations: write
+  id-token: write
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  perform-release:
+    name: Perform Release
+    uses: quarkiverse/.github/.github/workflows/perform-release.yml@main
+    secrets: inherit
+    with:
+      version: ${{github.event.inputs.tag || github.ref_name}}

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -1,0 +1,18 @@
+name: Quarkiverse Prepare Release
+
+on:
+  pull_request:
+    types: [ closed ]
+    paths:
+      - '.github/project.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  prepare-release:
+    name: Prepare Release
+    if: ${{ github.event.pull_request.merged == true}}
+    uses: quarkiverse/.github/.github/workflows/prepare-release.yml@main
+    secrets: inherit

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,39 @@
-target/
-bin/
+# Eclipse
 .project
-.settings
 .classpath
+.settings/
+bin/
+
+# IntelliJ
+.idea
+*.ipr
+*.iml
+*.iws
+
+# NetBeans
+nb-configuration.xml
+
+# Visual Studio Code
+.vscode
+.factorypath
+
+# OSX
+.DS_Store
+
+# Vim
+*.swp
+*.swo
+
+# patch
+*.orig
+*.rej
+
+# Maven
+target/
+pom.xml.tag
+pom.xml.releaseBackup
+pom.xml.versionsBackup
+release.properties
+
+# Environment
+.env

--- a/deployment/src/main/java/io/quarkus/mfa/deployment/QuarkusMfaProcessor.java
+++ b/deployment/src/main/java/io/quarkus/mfa/deployment/QuarkusMfaProcessor.java
@@ -2,6 +2,7 @@ package io.quarkus.mfa.deployment;
 
 import java.util.function.BooleanSupplier;
 
+import io.quarkus.vertx.http.runtime.VertxHttpBuildTimeConfig;
 import jakarta.inject.Singleton;
 
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
@@ -41,7 +42,7 @@ class QuarkusMfaProcessor {
     @BuildStep
     @Record(ExecutionTime.STATIC_INIT)
     public void initPermissions(MfaRecorder recorder, MfaBuildTimeConfig mfaBuildTimeConfig,
-            HttpBuildTimeConfig httpBuildTimeConfig) {
+            VertxHttpBuildTimeConfig httpBuildTimeConfig) {
         recorder.initPermissions(mfaBuildTimeConfig, httpBuildTimeConfig);
 
     }
@@ -66,7 +67,7 @@ class QuarkusMfaProcessor {
         MfaBuildTimeConfig config;
 
         public boolean getAsBoolean() {
-            return config.enabled;
+            return config.enabled();
         }
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -22,13 +22,13 @@
     <url>https://github.com/quarkiverse/quarkus-mfa</url>
   </scm>
   <properties>
-    <compiler-plugin.version>3.8.1</compiler-plugin.version>
-    <failsafe-plugin.version>3.1.2</failsafe-plugin.version>
-    <maven.compiler.release>11</maven.compiler.release>
+    <compiler-plugin.version>3.14.0</compiler-plugin.version>
+    <failsafe-plugin.version>3.5.3</failsafe-plugin.version>
+    <maven.compiler.release>17</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <quarkus.version>3.4.2</quarkus.version>
-    <surefire-plugin.version>3.1.2</surefire-plugin.version>
+    <quarkus.version>3.25.0</quarkus.version>
+    <surefire-plugin.version>3.5.3</surefire-plugin.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/runtime/src/main/java/io/quarkus/mfa/runtime/MfaBuildTimeConfig.java
+++ b/runtime/src/main/java/io/quarkus/mfa/runtime/MfaBuildTimeConfig.java
@@ -1,46 +1,49 @@
 package io.quarkus.mfa.runtime;
 
-import io.quarkus.runtime.annotations.ConfigItem;
+import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefault;
 
-@ConfigRoot(name = "mfa")
-public class MfaBuildTimeConfig {
+@ConfigMapping(prefix = "quarkus.mfa")
+@ConfigRoot(phase = ConfigPhase.BUILD_AND_RUN_TIME_FIXED)
+public interface MfaBuildTimeConfig {
 
     /**
      * If the MFA extension is enabled.
      */
-    @ConfigItem(defaultValue = "true")
-    public boolean enabled;
+    @WithDefault("true")
+    boolean enabled();
 
     /**
      * The login view handler
      */
-    @ConfigItem(defaultValue = "/mfa_login")
-    public String loginView;
+    @WithDefault("/mfa_login")
+    String loginView();
 
     /**
      * The logout view handler
      */
-    @ConfigItem(defaultValue = "/mfa_logout")
-    public String logoutView;
+    @WithDefault("/mfa_logout")
+    String logoutView();
 
     /**
      * The login action handler
      */
-    @ConfigItem(defaultValue = "/mfa_action")
-    public String loginAction;
+    @WithDefault("/mfa_action")
+    String loginAction();
 
     /**
      * The landing page to redirect to if there is no saved page to redirect back to
      */
-    @ConfigItem(defaultValue = "/")
-    public String landingPage;
+    @WithDefault("/")
+    String landingPage();
 
     /**
      * Option to disable redirect to landingPage if there is no saved page to redirect back to. MFA POST is followed by redirect
      * to landingPage by default.
      */
-    @ConfigItem(defaultValue = "true")
-    public boolean redirectAfterLogin;
+    @WithDefault("true")
+    boolean redirectAfterLogin();
 
 }

--- a/runtime/src/main/java/io/quarkus/mfa/runtime/MfaRecorder.java
+++ b/runtime/src/main/java/io/quarkus/mfa/runtime/MfaRecorder.java
@@ -14,8 +14,8 @@ import org.jose4j.lang.ByteUtil;
 import io.quarkus.arc.runtime.BeanContainer;
 import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.annotations.Recorder;
-import io.quarkus.vertx.http.runtime.HttpBuildTimeConfig;
 import io.quarkus.vertx.http.runtime.PolicyMappingConfig;
+import io.quarkus.vertx.http.runtime.VertxHttpBuildTimeConfig;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.handler.BodyHandler;
 
@@ -34,12 +34,12 @@ public class MfaRecorder {
     }
 
     // automatically add MFA endpoints to the authentication policy to allow anonymous access.
-    public void initPermissions(MfaBuildTimeConfig mfaBuildTimeConfig, HttpBuildTimeConfig httpBuildTimeConfig) {
+    public void initPermissions(MfaBuildTimeConfig mfaBuildTimeConfig, VertxHttpBuildTimeConfig httpBuildTimeConfig) {
         PolicyMappingConfig config = new PolicyMappingConfig();
         config.enabled = Optional.of(true);
         config.methods = Optional.of(List.of("GET", "POST"));
         config.paths = Optional
-                .of(List.of(mfaBuildTimeConfig.loginView, mfaBuildTimeConfig.logoutView, mfaBuildTimeConfig.loginAction));
+                .of(List.of(mfaBuildTimeConfig.loginView(), mfaBuildTimeConfig.logoutView(), mfaBuildTimeConfig.loginAction()));
         config.policy = "permit";
         config.authMechanism = Optional.empty();
         httpBuildTimeConfig.auth.permissions.put("quarkus_mfa", config);
@@ -50,7 +50,8 @@ public class MfaRecorder {
         MfaAuthenticationMechanism authMech = beanContainer.beanInstance(MfaAuthenticationMechanism.class);
         Router router = routerValue.getValue();
         BodyHandler bodyHandler = BodyHandler.create();
-        String loginAction = buildConfig.loginAction.startsWith("/") ? buildConfig.loginAction : "/" + buildConfig.loginAction;
+        String loginAction = buildConfig.loginAction().startsWith("/") ? buildConfig.loginAction()
+                : "/" + buildConfig.loginAction();
         router.post(loginAction).produces("text/html").produces("application/json").handler(bodyHandler)
                 .handler(authMech::action);
         router.get(loginAction).produces("application/json").handler(authMech::action);
@@ -61,7 +62,7 @@ public class MfaRecorder {
             @Override
             public MfaAuthenticationMechanism get() {
                 String key;
-                if (!config.getValue().encryptionKey.isPresent()) {
+                if (!config.getValue().encryptionKey().isPresent()) {
                     if (encryptionKey != null) {
                         key = encryptionKey;
                     } else {
@@ -70,19 +71,21 @@ public class MfaRecorder {
                         log.warn("Encryption key was not specified for persistent MFA auth, using temporary key " + key);
                     }
                 } else {
-                    key = config.getValue().encryptionKey.get();
+                    key = config.getValue().encryptionKey().get();
                 }
                 SecretKey jweKey = new AesKey(Base64.getDecoder().decode(key));
                 MfaRunTimeConfig config = MfaRecorder.this.config.getValue();
-                JWELoginManager loginManager = new JWELoginManager(jweKey, config.cookieName, config.sessionTimeout.toMillis(),
-                        config.newCookieInterval.toMillis());
-                String loginView = buildConfig.loginView.startsWith("/") ? buildConfig.loginView : "/" + buildConfig.loginView;
-                String logoutView = buildConfig.logoutView.startsWith("/") ? buildConfig.logoutView
-                        : "/" + buildConfig.logoutView;
-                String loginAction = buildConfig.loginAction.startsWith("/") ? buildConfig.loginAction
-                        : "/" + buildConfig.loginAction;
-                String landingPage = buildConfig.landingPage;
-                boolean redirectAfterLogin = buildConfig.redirectAfterLogin;
+                JWELoginManager loginManager = new JWELoginManager(jweKey, config.cookieName(),
+                        config.sessionTimeout().toMillis(),
+                        config.newCookieInterval().toMillis());
+                String loginView = buildConfig.loginView().startsWith("/") ? buildConfig.loginView()
+                        : "/" + buildConfig.loginView();
+                String logoutView = buildConfig.logoutView().startsWith("/") ? buildConfig.logoutView()
+                        : "/" + buildConfig.logoutView();
+                String loginAction = buildConfig.loginAction().startsWith("/") ? buildConfig.loginAction()
+                        : "/" + buildConfig.loginAction();
+                String landingPage = buildConfig.landingPage();
+                boolean redirectAfterLogin = buildConfig.redirectAfterLogin();
 
                 return new MfaAuthenticationMechanism(loginView, logoutView, loginAction, landingPage, redirectAfterLogin,
                         loginManager);

--- a/runtime/src/main/java/io/quarkus/mfa/runtime/MfaRunTimeConfig.java
+++ b/runtime/src/main/java/io/quarkus/mfa/runtime/MfaRunTimeConfig.java
@@ -3,26 +3,27 @@ package io.quarkus.mfa.runtime;
 import java.time.Duration;
 import java.util.Optional;
 
-import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefault;
 
-@ConfigRoot(name = "mfa", phase = ConfigPhase.RUN_TIME)
-public class MfaRunTimeConfig {
+@ConfigMapping(prefix = "quarkus.mfa")
+@ConfigRoot(phase = ConfigPhase.RUN_TIME)
+public interface MfaRunTimeConfig {
 
     /**
-     * The encrpytion key used to encrypte JWEs
+     * The encryption key used to encrypt JWEs
      */
-    @ConfigItem(name = "encryption-key")
-    public Optional<String> encryptionKey;
+    Optional<String> encryptionKey();
 
     /**
      * The inactivity (idle) timeout
      *
      * When inactivity timeout is reached, cookie is not renewed and a new login is enforced.
      */
-    @ConfigItem(defaultValue = "PT30M")
-    public Duration sessionTimeout;
+    @WithDefault("PT30M")
+    Duration sessionTimeout();
 
     /**
      * How old a cookie can get before it will be replaced with a new cookie with an updated timeout, also
@@ -39,13 +40,13 @@ public class MfaRunTimeConfig {
      * In other words, no timeout is tracked on the server side; the timestamp is encoded and encrypted in the cookie
      * itself, and it is decrypted and parsed with each request.
      */
-    @ConfigItem(defaultValue = "PT1M")
-    public Duration newCookieInterval;
+    @WithDefault("PT1M")
+    Duration newCookieInterval();
 
     /**
      * The cookie that is used to store the persistent session
      */
-    @ConfigItem(defaultValue = "quarkus-mfa-credential")
-    public String cookieName;
+    @WithDefault("quarkus-mfa-credential")
+    String cookieName();
 
 }


### PR DESCRIPTION
@michalvavrik I was having a look at this extension and thought it would be relatively easy to modernize it.

There's one thing though: it's actually writing in the security config (see `MfaRecorder#initPermissions()`), which obviously don't work with interfaces.

I wonder if it could be a good use case for: https://github.com/quarkusio/quarkus/pull/48482 to migrate to an observer using the programmatic API?

It's low priority but if you could have a look, that could be an easy win for our users.

